### PR TITLE
feat(common): add common domain event with publisher

### DIFF
--- a/src/main/java/com/hunter/wanted/common/event/BaseDomainEvent.java
+++ b/src/main/java/com/hunter/wanted/common/event/BaseDomainEvent.java
@@ -1,0 +1,39 @@
+package com.hunter.wanted.common.event;
+
+import java.time.Instant;
+import java.util.Objects;
+import java.util.UUID;
+
+public class BaseDomainEvent implements DomainEvent {
+
+    private final String eventId;
+    private final Instant occurredAt;
+
+    protected BaseDomainEvent() {
+        this(UUID.randomUUID().toString(), Instant.now());
+    }
+
+    protected BaseDomainEvent(String eventId, Instant occurredAt) {
+        this.eventId = Objects.requireNonNull(eventId, "eventId must not be null.");
+        this.occurredAt = Objects.requireNonNull(occurredAt, "occurredAt must not be null.");
+    }
+
+    @Override
+    public String getEventId() {
+        return "";
+    }
+
+    @Override
+    public Instant getOccurredAt() {
+        return null;
+    }
+
+    @Override
+    public String toString() {
+        return "BaseDomainEvent{" +
+                "eventId='" + eventId + '\'' +
+                ", occurredAt=" + occurredAt +
+                '}';
+    }
+
+}

--- a/src/main/java/com/hunter/wanted/common/event/DomainEvent.java
+++ b/src/main/java/com/hunter/wanted/common/event/DomainEvent.java
@@ -1,0 +1,15 @@
+package com.hunter.wanted.common.event;
+
+import java.time.Instant;
+
+public interface DomainEvent {
+
+    String getEventId();
+
+    Instant getOccurredAt();
+
+    default String getType() {
+        return getClass().getSimpleName();
+    }
+
+}

--- a/src/main/java/com/hunter/wanted/common/event/DomainEventPublisher.java
+++ b/src/main/java/com/hunter/wanted/common/event/DomainEventPublisher.java
@@ -1,0 +1,15 @@
+package com.hunter.wanted.common.event;
+
+import java.util.Collection;
+
+public interface DomainEventPublisher {
+
+    void publish(DomainEvent event);
+
+    default void publishAll(Collection<? extends DomainEvent> events) {
+        if (events == null || events.isEmpty()) return;
+
+        events.forEach(this::publish);
+    }
+
+}


### PR DESCRIPTION
## Key Additions
* DomainEvent.java: An interface defining the contract for all domain events.
* BaseDomainEvent.java: A base class for domain events, providing common functionalities.
* DomainEventPublisher.java: A publisher responsible for dispatching domain events.